### PR TITLE
FEATURE: Introduce Netlogix.ErrorHandler.generatePages setting

### DIFF
--- a/Classes/Command/ErrorPageCommandController.php
+++ b/Classes/Command/ErrorPageCommandController.php
@@ -31,6 +31,12 @@ class ErrorPageCommandController extends CommandController
 {
 
     /**
+     * @Flow\InjectConfiguration(path="generatePages")
+     * @var bool
+     */
+    protected $generatePages;
+
+    /**
      * @Flow\Inject
      * @var Bootstrap
      */
@@ -75,6 +81,11 @@ class ErrorPageCommandController extends CommandController
      */
     public function generateCommand(bool $verbose = false)
     {
+        if (!$this->generatePages) {
+            $verbose && $this->outputLine('Skipping generation because Netlogix.ErrorHandler.generatePages is false');
+            $this->sendAndExit(0);
+        }
+
         $client = new Client([
             'verify' => $this->bootstrap->getContext()->isProduction()
         ]);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -13,7 +13,7 @@ Neos:
 
 Netlogix:
   ErrorHandler:
-
+    generatePages: true
     pages: []
 
 #      'my-site':


### PR DESCRIPTION
If false, no error pages will be generated when the errorpage:generate
command is run.