### PR TITLE
BUGFIX: Only set ProductionExceptionHandler for Production Context

### DIFF
--- a/Configuration/Production/Settings.yaml
+++ b/Configuration/Production/Settings.yaml
@@ -1,0 +1,5 @@
+Neos:
+  Flow:
+    error:
+      exceptionHandler:
+        className: Netlogix\ErrorHandler\Handler\ProductionExceptionHandler

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,8 +2,6 @@ Neos:
   Flow:
     error:
       exceptionHandler:
-        className: Netlogix\ErrorHandler\Handler\ProductionExceptionHandler
-
         renderingGroups:
           serverErrorExceptions:
             matchingStatusCodes: [ 500 ]


### PR DESCRIPTION
When running in Development Context, the ExceptionHandler should not
be an instance of the ProductionExceptionHandler, as it does not
print debug information.