### PR TITLE
BUGFIX: Fix static error pages on Flow 6.3.16+

### DIFF
--- a/Classes/Handler/ProductionExceptionHandler.php
+++ b/Classes/Handler/ProductionExceptionHandler.php
@@ -67,4 +67,14 @@ class ProductionExceptionHandler extends FlowProductionExceptionHandler
         );
     }
 
+    /**
+     * Override new method introduced in Flow 6.3.16
+     *
+     * @return bool
+     */
+    protected function useCustomErrorView(): bool
+    {
+        return false;
+    }
+
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,11 +3,6 @@ Neos:
     error:
       exceptionHandler:
         renderingGroups:
-          notFoundExceptions:
-            options:
-              # Force static exception rendering.
-              templatePathAndFilename: null
-              viewClassName: Neos\FluidAdaptor\View\StandaloneView
           serverErrorExceptions:
             matchingStatusCodes: [ 500 ]
             options:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": "~7.2",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "~6.0 || ~7.0",
-        "neos/neos": "~5.0"
+        "neos/neos": "^5.0",
+        "neos/flow": "^6.3.16"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Prior to https://github.com/neos/flow-development-collection/pull/2638 Flow used `isset()` to check the `templatePathAndFileName`, which evaluated to `false` for `null`.

That PR also introduced the method `useCustomErrorView()` which we can now use to override the behavior.