### PR TITLE
BUGFIX: Set templatePathAndFilename for serverErrorExceptions to prevent "Template not found"

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,6 +7,7 @@ Neos:
             matchingStatusCodes: [ 500 ]
             options:
               logException: true
+              templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
 
 Netlogix:
   ErrorHandler:


### PR DESCRIPTION
useCustomErrorView() of the AbstractExceptionHandler only checks if the array key templatePathAndFilename is set, but not if it's a valid string. This means that setting templatePathAndFilename to null will cause an exception during exception rendering, hiding the original error.

This only affects Development, as our own implementation of the ProductionExceptionHandler always returns false for `useCustomErrorView()`.