### PR TITLE
fix: Sort NodeBasedConfiguration by length of pathPrefixes

### DIFF
--- a/Classes/Command/ErrorPageCommandController.php
+++ b/Classes/Command/ErrorPageCommandController.php
@@ -147,7 +147,7 @@ class ErrorPageCommandController extends CommandController
     public function showConfigurationCommand()
     {
         $result = [
-            'Neltogix' => [
+            'Netlogix' => [
                 'ErrorHandler' => [
                     'pages' => $this->configuration->getConfiguration()
               ]

--- a/Classes/Configuration/NodeBasedConfiguration.php
+++ b/Classes/Configuration/NodeBasedConfiguration.php
@@ -103,6 +103,9 @@ class NodeBasedConfiguration
                     $this->throwableStorage->logThrowable($e);
                 }
             }
+
+            usort($configurationsForSite[$sitename], fn($a, $b) => $a['position'] <=> $b['position']);
+            $configurationsForSite[$sitename] = array_map(fn($item) => array_diff_key($item, ['position' => 0]), $configurationsForSite[$sitename]);
             $configurationsForSite[$sitename] = array_values($configurationsForSite[$sitename]);
         }
 
@@ -111,13 +114,20 @@ class NodeBasedConfiguration
 
     public function getErrorNodeConfiguration(NodeInterface $errorNode): array
     {
+        $pathPrefixes = $this->extractPathPrefixes($errorNode);
+        $position = 1000;
+        foreach ($pathPrefixes as $pathPrefix) {
+            $position -= strlen($pathPrefix);
+        }
+
         return [
             'matchingStatusCodes' => $this->extractStatusCodes($errorNode),
             'dimensions' => $this->extractDimensions($errorNode),
             'dimensionPathSegment' => $this->extractDimensionsPathSegment($errorNode),
             'source' => '#' . $errorNode->getIdentifier(),
             'destination' => $this->destination,
-            'pathPrefixes' => $this->extractPathPrefixes($errorNode),
+            'pathPrefixes' => $pathPrefixes,
+            'position' => $position,
         ];
     }
 


### PR DESCRIPTION
This is required so an error page at path /foo takes precendence over the error page at path /